### PR TITLE
Avoid premature apt cache refresh

### DIFF
--- a/roles/nomad/tasks/main.yml
+++ b/roles/nomad/tasks/main.yml
@@ -3,7 +3,6 @@
   apt:
     name: [curl, gnupg, ca-certificates, software-properties-common]
     state: present
-    update_cache: true
 
 # --- HashiCorp repo setup (official docs)
 - name: Ensure apt keyrings dir exists


### PR DESCRIPTION
## Summary
- prevent early apt cache refresh before HashiCorp repo is added

## Testing
- `ansible-playbook -i inventory/hosts.yml site.yml` *(fails: Failed to connect to the host via ssh: ssh: connect to host 198.19.249.229 port 22: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ebbe579c832da34f97533d946b1a